### PR TITLE
cancellation_terms_uri should be optional

### DIFF
--- a/src/klarna.js
+++ b/src/klarna.js
@@ -25,7 +25,6 @@
     merchant: {
       id: null,
       terms_uri: null,
-      cancellation_terms_uri: null,
       checkout_uri: null,
       confirmation_uri: null,
       push_uri: null


### PR DESCRIPTION
Having cancellation_terms_uri default to null makes it required. According to the Klarna docs, it is optional.

https://developers.klarna.com/en/se/kco-v2/checkout-api#merchant-object-properties
