### PR TITLE
Made the hash data encoding explicit.

### DIFF
--- a/src/klarna.coffee
+++ b/src/klarna.coffee
@@ -48,7 +48,7 @@ httpRequest =
 
     # Create (digestive) biscuit from payload and hash from biscuit
     biscuit = if payload? then JSON.stringify(payload) + credentials.secret else credentials.secret
-    hash = crypto.createHash('sha256').update(biscuit).digest('base64')
+    hash = crypto.createHash('sha256').update(biscuit, 'utf-8').digest('base64')
 
     # Return headers
     'Accept': klarna.headers.accept


### PR DESCRIPTION
The hashing should be done in utf-8 mode, since the string is utf-8. Before Node v6, the default was binary.

https://nodejs.org/api/crypto.html#crypto_hash_update_data_input_encoding
https://github.com/nodejs/node/issues/6813
